### PR TITLE
Add local Gateway API demo with Colima

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# Local Gateway API Demo on macOS with Colima
+
+This repository contains example manifests and instructions for testing the Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) on macOS using [Colima](https://github.com/abiosoft/colima).
+
+## Prerequisites
+
+- macOS with [Homebrew](https://brew.sh/) installed
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) command-line tool
+- [`colima`](https://github.com/abiosoft/colima) for running Kubernetes locally
+- [`istioctl`](https://istio.io/latest/docs/setup/install/istioctl/) to install the Istio controller
+
+Install the tools via Homebrew:
+
+```bash
+brew install kubectl colima istioctl
+```
+
+## Start Colima with Kubernetes
+
+Create a local cluster with enough resources:
+
+```bash
+colima start --cpu 2 --memory 4 --disk 20 --kubernetes
+```
+
+Colima will create a Kubernetes context named `colima`. Verify it:
+
+```bash
+kubectl config current-context
+kubectl get nodes
+```
+
+## Install Gateway API CRDs
+
+Apply the official Gateway API CRDs to the cluster:
+
+```bash
+kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0"
+```
+
+## Install Istio minimal profile
+
+The manifests in this repository use Istio as the Gateway API controller. Install it with `istioctl`:
+
+```bash
+istioctl install --set profile=minimal -y
+```
+
+## Deploy the example
+
+Apply all manifests from the `manifests` directory:
+
+```bash
+kubectl apply -f manifests/
+```
+
+This creates:
+
+- An `istio` `GatewayClass`
+- A `demo-gateway` `Gateway` in the `infra` namespace
+- Two application namespaces (`app1` and `app2`) labeled so they can attach HTTPRoutes
+- Echo deployments and services in each namespace
+- Example `HTTPRoute` objects `echo.example.com` and `echo2.example.com`
+- RBAC Roles and bindings that only let each team manage resources in its own namespace
+
+The included `rbac.yaml` manifest defines Roles and RoleBindings limiting each
+team to its own namespace. Team A operates in `app1` using the `dev-team-a`
+ServiceAccount, while Team B uses `dev-team-b` in `app2`. Neither service
+account has permissions in the other team's namespace or the `infra` namespace.
+
+Wait for the gateway to be ready:
+
+```bash
+kubectl get gateway -n infra
+```
+
+## Access the application
+
+Find the external address of the gateway service (provided by Istio):
+
+```bash
+kubectl get svc istio-ingressgateway -n istio-system
+```
+
+Map the address to each example host and curl it (replace `ADDRESS` with the `EXTERNAL-IP` or `CLUSTER-IP` you get above):
+
+```bash
+# app1
+curl -H "Host: echo.example.com" http://ADDRESS/
+# app2
+curl -H "Host: echo2.example.com" http://ADDRESS/
+```
+
+You should see `hello from echo-app` and `hello from echo-app-2` in the respective responses.
+
+## Cleanup
+
+To stop the cluster:
+
+```bash
+colima stop
+```
+
+You can delete it entirely with `colima delete` if desired.

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-app
+  namespace: app1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo-app
+  template:
+    metadata:
+      labels:
+        app: echo-app
+    spec:
+      containers:
+      - name: echo
+        image: hashicorp/http-echo:0.2.3
+        args:
+        - "-text=hello from echo-app"
+        ports:
+        - containerPort: 5678
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-app
+  namespace: app2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo-app
+  template:
+    metadata:
+      labels:
+        app: echo-app
+    spec:
+      containers:
+      - name: echo
+        image: hashicorp/http-echo:0.2.3
+        args:
+        - "-text=hello from echo-app-2"
+        ports:
+        - containerPort: 5678

--- a/manifests/gateway.yaml
+++ b/manifests/gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: demo-gateway
+  namespace: infra
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            gateway-access: "true"

--- a/manifests/gatewayclass.yaml
+++ b/manifests/gatewayclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controllerName: istio.io/gateway-controller

--- a/manifests/httproute.yaml
+++ b/manifests/httproute.yaml
@@ -1,0 +1,39 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-route
+  namespace: app1
+spec:
+  parentRefs:
+  - name: demo-gateway
+    namespace: infra
+  hostnames:
+  - "echo.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: echo-svc
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-route
+  namespace: app2
+spec:
+  parentRefs:
+  - name: demo-gateway
+    namespace: infra
+  hostnames:
+  - "echo2.example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: echo-svc
+      port: 80

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: infra
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app1
+  labels:
+    gateway-access: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app2
+  labels:
+    gateway-access: "true"

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dev-team-a
+  namespace: app1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dev-role
+  namespace: app1
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dev-binding
+  namespace: app1
+subjects:
+- kind: ServiceAccount
+  name: dev-team-a
+  namespace: app1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dev-role
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dev-team-b
+  namespace: app2
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dev-role
+  namespace: app2
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dev-binding
+  namespace: app2
+subjects:
+- kind: ServiceAccount
+  name: dev-team-b
+  namespace: app2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dev-role

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-svc
+  namespace: app1
+spec:
+  selector:
+    app: echo-app
+  ports:
+  - port: 80
+    targetPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-svc
+  namespace: app2
+spec:
+  selector:
+    app: echo-app
+  ports:
+  - port: 80
+    targetPort: 5678


### PR DESCRIPTION
## Summary
- add instructions for installing and running Gateway API with Colima on macOS
- provide example manifests for GatewayClass, Gateway, HTTPRoute, deployment, service, and namespaces
- expand example to include two tenant namespaces and RBAC restrictions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68635d461ef8832696fcdf5767a3be1a